### PR TITLE
SSH with `root` log-in fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,13 @@ MAINTAINER Juan Lebrijo "juan@lebrijo.com"
 # DEPENDENCIES
 RUN apt-get -y update
 
+## Babil:: SSH with `root` log-in fix
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+## Babil:: enable password authentication for `root`; CHANGE THE PASSWORD AFTER FIRST RUN
+RUN echo 'root:===CHANGE-ME===' | chpasswd
+RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
 # CHEF-SOLO
 RUN apt-get -y install curl build-essential libxml2-dev libxslt-dev git
 RUN curl -L https://www.opscode.com/chef/install.sh | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get -y update
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
 ## Babil:: enable password authentication for `root`; CHANGE THE PASSWORD AFTER FIRST RUN
-RUN echo 'root:===CHANGE-ME===' | chpasswd
-RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+#RUN echo 'root:===CHANGE-ME===' | chpasswd
+#RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
 # CHEF-SOLO
 RUN apt-get -y install curl build-essential libxml2-dev libxslt-dev git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Base server = Ubuntu + PostgreSQL + Nginx
 # OpenSSH + Chef-solo + Supervisor
 FROM ubuntu:14.04
-MAINTAINER Juan Lebrijo "juan@lebrijo.com"
+MAINTAINER Babil Golam Sarwar "gsbabil@gmail.com"
 
 # DEPENDENCIES
 RUN apt-get -y update


### PR DESCRIPTION
`/etc/pam.d/sshd` must be patched as shown below before `root` user can log into the Docker image through SSH. This pull request basically adds that into `Dockerfile`.

`sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd`
